### PR TITLE
Update readme for chrony with information on systems clock rate adjustment

### DIFF
--- a/miscellaneous/chrony/README.md
+++ b/miscellaneous/chrony/README.md
@@ -9,6 +9,17 @@ sudo chronyc -a makestep
 
 BTW, the computers should (probably) be in the same timezone.
 
+## Possible system's clock rate change
+
+Chrony synchronizes the time by adjusting the system's clock rate by up to ~8% (by default). This means that if chrony is active and the declared time server is not in sync (the makestep command has not been called), use of chrony leads to nonnegligible constant change of system's clock rate. Be aware that if chrony is installed, it will start automatically at boot whenever NTP-based automatic clock synchronization is enabled. So do not forget to disable chrony or NTP-based time synchronization if you do not plan to use it. To disable NTP-based synchronization, run:
+```bash
+sudo timedatectl set-ntp off
+```
+To temporary disable chrony, run:
+```bash
+sudo service chrony restart
+```
+
 ## install chrony client
 
 ```bash


### PR DESCRIPTION
This pull request updates the readme for chrony with information on possible constant system's clock rate adjustment when chrony is active but make step has not been called. This situation can lead to increase or decrease of the systems clock rate by ~8% by default. In a result, e.g., mavros can be running on 92 Hz (considering systems clock) or the rate of incoming data from sensors may seem to be lower than it is when measured in real time. 

It also adds information that chrony starts automatically when NTP-based clock synchronization is enabled, so its constant clock rate adjustments can affect anyone working with UAVs with installed chrony, unless chrony is explicitly stopped or automatic time synchronization is disabled.