### PR TITLE
[ROS2] fix: Add ODOMETRY stream to extras.txt

### DIFF
--- a/miscellaneous/pixhawk_sdcard_config/pixhawk_4/etc/extras.txt
+++ b/miscellaneous/pixhawk_sdcard_config/pixhawk_4/etc/extras.txt
@@ -4,6 +4,7 @@ mavlink stream -d /dev/ttyS2 -s ATTITUDE_TARGET -r 100
 mavlink stream -d /dev/ttyS2 -s HIGHRES_IMU -r 100
 mavlink stream -d /dev/ttyS2 -s RC_CHANNELS -r 10
 mavlink stream -d /dev/ttyS2 -s LOCAL_POSITION_NED -r 100
+mavlink stream -d /dev/ttyS2 -s ODOMETRY -r 100
 mavlink stream -d /dev/ttyS2 -s GLOBAL_POSITION_INT -r 100
 mavlink stream -d /dev/ttyS2 -s SYS_STATUS -r 10
 mavlink stream -d /dev/ttyS2 -s DISTANCE_SENSOR -r 100


### PR DESCRIPTION
# Summary
These changes are needed to ensure compatibility with Pixhawk firmware version 1.16 and the latest version of the MRS system. The odometry message is crucial for acquiring the drone's orientation.

## Testing Status
This has already been tested with a drone in the F4F environment.

This could potentially resolve the issue mentioned in https://github.com/ctu-mrs/mrs_uav_px4_api/issues/5.